### PR TITLE
TST: Exclude python 3.6 tests of `macos-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,10 @@ jobs:
           - os: ubuntu-latest
             special: '; pre-release'
             version: 3.9
+        exclude:
+          - os: macos-latest
+            special: ''
+            version: 3.6
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
Python 3.6 will be unavailable on the to-be introduced macOS-11 default (xref https://github.com/actions/virtual-environments/issues/4060).